### PR TITLE
fix: Tool.createDir()

### DIFF
--- a/packages/core/Tool.server.js
+++ b/packages/core/Tool.server.js
@@ -46,7 +46,7 @@ class Tool extends Base {
      */
     static async createDir(dirPath) {
         const exist = await Tool.exist(dirPath);
-        if (!exist) return !!fs.promises.mkdir(dirPath, { recursive: true });
+        if (!exist) return fs.promises.mkdir(dirPath, { recursive: true });
         return Promise.resolve(null);
     }
 


### PR DESCRIPTION
Prefixing a promise with`!!` seems to breaks the async/await. 

This PR fixes #5
Should help also with #3 